### PR TITLE
Added an audit ReplayClient which can be used to manage audit replays.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <url>https://github.com/NationalSecurityAgency/datawave-spring-boot-starter-audit</url>
     </scm>
     <properties>
-        <version.microservice.audit-api>1.4</version.microservice.audit-api>
+        <version.microservice.audit-api>1.8</version.microservice.audit-api>
         <version.microservice.authorization-api>1.4</version.microservice.authorization-api>
         <version.microservice.starter>1.6.3</version.microservice.starter>
     </properties>

--- a/src/main/java/datawave/microservice/audit/replay/ReplayClient.java
+++ b/src/main/java/datawave/microservice/audit/replay/ReplayClient.java
@@ -1,0 +1,409 @@
+package datawave.microservice.audit.replay;
+
+import com.google.common.base.Preconditions;
+import datawave.microservice.audit.AuditServiceProvider;
+import datawave.microservice.audit.replay.status.Status;
+import datawave.microservice.authorization.jwt.JWTRestTemplate;
+import datawave.microservice.authorization.user.ProxiedUserDetails;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.cloud.client.ServiceInstance;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.util.UriComponents;
+import org.springframework.web.util.UriComponentsBuilder;
+
+/**
+ * Simple rest client for submitting requests to the audit replay service
+ *
+ * @see Request
+ * @see AuditServiceProvider
+ */
+@Service
+@ConditionalOnProperty(name = "audit-client.enabled", havingValue = "true", matchIfMissing = true)
+public class ReplayClient {
+    
+    private static final String DEFAULT_REQUEST_BASE_PATH = "/v1/replay";
+    
+    private enum ReplayMethod {
+        CREATE("create", HttpMethod.POST, String.class),
+        CREATE_AND_START("createAndStart", HttpMethod.POST, String.class),
+        START("start", HttpMethod.PUT, String.class),
+        START_ALL("startAll", HttpMethod.PUT, String.class),
+        STATUS("status", HttpMethod.GET, Status.class),
+        STATUS_ALL("statusAll", HttpMethod.GET, Status[].class),
+        UPDATE("update", HttpMethod.PUT, String.class),
+        UPDATE_ALL("updateAll", HttpMethod.PUT, String.class),
+        STOP("stop", HttpMethod.PUT, String.class),
+        STOP_ALL("stopAll", HttpMethod.PUT, String.class),
+        RESUME("resume", HttpMethod.PUT, String.class),
+        RESUME_ALL("resumeAll", HttpMethod.PUT, String.class),
+        DELETE("delete", HttpMethod.DELETE, String.class),
+        DELETE_ALL("deleteAll", HttpMethod.DELETE, String.class);
+        
+        private String name;
+        private HttpMethod httpMethod;
+        private Class responseClass;
+        
+        ReplayMethod(String name, HttpMethod httpMethod, Class responseClass) {
+            this.name = name;
+            this.httpMethod = httpMethod;
+            this.responseClass = responseClass;
+        }
+        
+        public String getName() {
+            return name;
+        }
+        
+        public HttpMethod getHttpMethod() {
+            return httpMethod;
+        }
+        
+        public Class getResponseClass() {
+            return responseClass;
+        }
+    }
+    
+    private final Logger log = LoggerFactory.getLogger(this.getClass());
+    private final AuditServiceProvider serviceProvider;
+    private final JWTRestTemplate jwtRestTemplate;
+    
+    @Autowired
+    public ReplayClient(RestTemplateBuilder builder, AuditServiceProvider serviceProvider) {
+        this.jwtRestTemplate = builder.build(JWTRestTemplate.class);
+        this.serviceProvider = serviceProvider;
+    }
+    
+    /**
+     * Creates an audit replay request
+     *
+     * @param request
+     *            Used to set applicable parameters (see below) and to specify the user details for this request. Request Parameters: pathUri (required) The
+     *            path where the audit file(s) to be replayed can be found sendRate (optional) The number of messages to send per second replayUnfinishedFiles
+     *            (optional) Indicates whether files from an unfinished audit replay should be included
+     * @return the audit replay id
+     */
+    public String create(Request request) {
+        validateRequest(request);
+        Preconditions.checkNotNull(request.paramMap, "pathUri cannot be null");
+        Preconditions.checkNotNull(request.paramMap.get("pathUri"), "pathUri cannot be null");
+        
+        return (String) submitRequest(ReplayMethod.CREATE, request);
+    }
+    
+    /**
+     * Creates an audit replay request, and starts it
+     *
+     * @param request
+     *            Used to set applicable parameters (see below) and to specify the user details for this request. Request Parameters: pathUri (required) The
+     *            path where the audit file(s) to be replayed can be found sendRate (optional) The number of messages to send per second replayUnfinishedFiles
+     *            (optional) Indicates whether files from an unfinished audit replay should be included
+     * @return the audit replay id
+     */
+    public String createAndStart(Request request) {
+        validateRequest(request);
+        Preconditions.checkNotNull(request.paramMap, "pathUri cannot be null");
+        Preconditions.checkNotNull(request.paramMap.get("pathUri"), "pathUri cannot be null");
+        
+        return (String) submitRequest(ReplayMethod.CREATE_AND_START, request);
+    }
+    
+    /**
+     * Starts an audit replay
+     *
+     * @param request
+     *            Used to set applicable parameters (see below) and to specify the user details for this request. Request Parameters: id (required) The audit
+     *            replay id
+     * @return status, indicating whether the audit replay was started successfully
+     */
+    public String start(Request request) {
+        validateRequest(request);
+        Preconditions.checkNotNull(request.id, "id cannot be null");
+        
+        return (String) submitRequest(ReplayMethod.START, request);
+    }
+    
+    /**
+     * Starts all audit replays
+     *
+     * @param request
+     *            Used to specify the user details for this request.
+     * @return status, indicating the number of audit replays which were successfully started
+     */
+    public String startAll(Request request) {
+        validateRequest(request);
+        
+        return (String) submitRequest(ReplayMethod.START_ALL, request);
+    }
+    
+    /**
+     * Gets the status of an audit replay
+     *
+     * @param request
+     *            Used to set applicable parameters (see below) and to specify the user details for this request. Request Parameters: id (required) The audit
+     *            replay id
+     * @return the status of the audit replay
+     */
+    public Status status(Request request) {
+        validateRequest(request);
+        Preconditions.checkNotNull(request.id, "id cannot be null");
+        
+        return (Status) submitRequest(ReplayMethod.STATUS, request);
+    }
+    
+    /**
+     * Lists the status for all audit replays
+     *
+     * @param request
+     *            Used to specify the user details for this request.
+     * @return array of statuses for all audit replays
+     */
+    public Status[] statusAll(Request request) {
+        validateRequest(request);
+        
+        return (Status[]) submitRequest(ReplayMethod.STATUS_ALL, request);
+    }
+    
+    /**
+     * Updates an audit replay
+     *
+     * @param request
+     *            Used to set applicable parameters (see below) and to specify the user details for this request. Request Parameters: id (required) The audit
+     *            replay id sendRate (required) The number of messages to send per second
+     * @return status, indicating whether the update was successful
+     */
+    public String update(Request request) {
+        validateRequest(request);
+        Preconditions.checkNotNull(request.id, "id cannot be null");
+        Preconditions.checkNotNull(request.paramMap, "sendRate cannot be null");
+        Preconditions.checkNotNull(request.paramMap.get("sendRate"), "sendRate cannot be null");
+        
+        return (String) submitRequest(ReplayMethod.UPDATE, request);
+    }
+    
+    /**
+     * Updates all audit replays
+     *
+     * @param request
+     *            Used to set applicable parameters (see below) and to specify the user details for this request. Request Parameters: sendRate (required) The
+     *            number of messages to send per second
+     * @return status, indicating the number of audit replays which were successfully updated
+     */
+    public String updateAll(Request request) {
+        validateRequest(request);
+        Preconditions.checkNotNull(request.paramMap, "sendRate cannot be null");
+        Preconditions.checkNotNull(request.paramMap.get("sendRate"), "sendRate cannot be null");
+        
+        return (String) submitRequest(ReplayMethod.UPDATE_ALL, request);
+    }
+    
+    /**
+     * Stops an audit replay
+     *
+     * @param request
+     *            Used to set applicable parameters (see below) and to specify the user details for this request. Request Parameters: id (required) The audit
+     *            replay id
+     * @return status, indicating whether the audit replay was successfully stopped
+     */
+    public String stop(Request request) {
+        validateRequest(request);
+        Preconditions.checkNotNull(request.id, "id cannot be null");
+        
+        return (String) submitRequest(ReplayMethod.STOP, request);
+    }
+    
+    /**
+     * Stops all audit replays
+     *
+     * @param request
+     *            Used to specify the user details for this request.
+     * @return status, indicating the number of audit replays which were successfully stopped
+     */
+    public String stopAll(Request request) {
+        validateRequest(request);
+        
+        return (String) submitRequest(ReplayMethod.STOP_ALL, request);
+    }
+    
+    /**
+     * Resumes an audit replay
+     *
+     * @param request
+     *            Used to set applicable parameters (see below) and to specify the user details for this request. Request Parameters: id (required) The audit
+     *            replay id
+     * @return status, indicating whether the audit replay was successfully resumed
+     */
+    public String resume(Request request) {
+        validateRequest(request);
+        Preconditions.checkNotNull(request.id, "id cannot be null");
+        
+        return (String) submitRequest(ReplayMethod.RESUME, request);
+    }
+    
+    /**
+     * Resumes all audit replays
+     *
+     * @param request
+     *            Used to specify the user details for this request.
+     * @return status, indicating the number of audit replays which were successfully resumed
+     */
+    public String resumeAll(Request request) {
+        validateRequest(request);
+        
+        return (String) submitRequest(ReplayMethod.RESUME_ALL, request);
+    }
+    
+    /**
+     * Deletes an audit replay
+     *
+     * @param request
+     *            Used to set applicable parameters (see below) and to specify the user details for this request. Request Parameters: id (required) The audit
+     *            replay id
+     * @return status, indicating whether the audit replay was successfully deleted
+     */
+    public String delete(Request request) {
+        validateRequest(request);
+        Preconditions.checkNotNull(request.id, "id cannot be null");
+        
+        return (String) submitRequest(ReplayMethod.DELETE, request);
+    }
+    
+    /**
+     * Deletes all audit replays
+     *
+     * @param request
+     *            Used to specify the user details for this request.
+     * @return status, indicating the number of audit replays which were successfully deleted
+     */
+    public String deleteAll(Request request) {
+        validateRequest(request);
+        return (String) submitRequest(ReplayMethod.DELETE_ALL, request);
+    }
+    
+    protected void validateRequest(Request request) {
+        Preconditions.checkNotNull(request, "request cannot be null");
+        Preconditions.checkNotNull(request.proxiedUserDetails, "proxiedUserDetails cannot be null");
+    }
+    
+    private Object submitRequest(ReplayMethod replayMethod, Request request) {
+        log.debug("Submitting {} request: {}", replayMethod.getName(), request.paramMap);
+        
+        String subPath = (request.id != null) ? request.id + "/" + replayMethod.getName() : replayMethod.getName();
+        
+        //@formatter:off
+        ServiceInstance auditService = serviceProvider.getServiceInstance();
+        UriComponents uri = UriComponentsBuilder.fromUri(auditService.getUri())
+                .path(auditService.getServiceId() + DEFAULT_REQUEST_BASE_PATH + "/" + subPath)
+                .build();
+
+        log.debug("Submitting {} request to {}", replayMethod.getName(), uri);
+
+        ResponseEntity<?> response = jwtRestTemplate.exchange(
+                jwtRestTemplate.createRequestEntity(
+                        request.proxiedUserDetails,
+                        request.paramMap,
+                        null,
+                        replayMethod.getHttpMethod(), uri),
+                replayMethod.getResponseClass()
+        );
+
+        if (response.getStatusCode().value() != HttpStatus.OK.value()) {
+            String errorMessage = String.format("%s request failed. Http Status: (%s, %s)",
+                    replayMethod.getName(),
+                    response.getStatusCodeValue(),
+                    response.getStatusCode().getReasonPhrase());
+            log.error(errorMessage);
+            throw new RuntimeException(errorMessage);
+        }
+        //@formatter:on
+        
+        return response.getBody();
+    }
+    
+    /**
+     * Replay request for a given query
+     *
+     * @see Request.Builder
+     */
+    public static class Request {
+        protected ProxiedUserDetails proxiedUserDetails;
+        protected String id;
+        protected MultiValueMap<String,String> paramMap;
+        
+        private Request() {
+            
+        }
+        
+        /**
+         * Used to construct replay requests
+         *
+         * @param builder
+         *            {@link Builder} for the replay request
+         */
+        protected Request(Builder builder) {
+            this.proxiedUserDetails = builder.proxiedUserDetails;
+            this.id = builder.id;
+            
+            MultiValueMap<String,String> paramMap = new LinkedMultiValueMap<>();
+            if (builder.pathUri != null) {
+                paramMap.add("pathUri", builder.pathUri);
+            }
+            if (builder.sendRate != null) {
+                paramMap.add("sendRate", Long.toString(builder.sendRate));
+            }
+            if (builder.replayUnfinishedFiles != null) {
+                paramMap.add("replayUnfinishedFiles", Boolean.toString(builder.replayUnfinishedFiles));
+            }
+            if (!paramMap.isEmpty()) {
+                this.paramMap = paramMap;
+            }
+        }
+        
+        /**
+         * Builder for replay requests
+         */
+        public static class Builder {
+            protected ProxiedUserDetails proxiedUserDetails;
+            protected String pathUri;
+            protected Long sendRate;
+            protected Boolean replayUnfinishedFiles;
+            protected String id;
+            
+            public Builder withProxiedUserDetails(ProxiedUserDetails proxiedUserDetails) {
+                this.proxiedUserDetails = proxiedUserDetails;
+                return this;
+            }
+            
+            public Builder withPathUri(String pathUri) {
+                this.pathUri = pathUri;
+                return this;
+            }
+            
+            public Builder withSendRate(Long sendRate) {
+                this.sendRate = sendRate;
+                return this;
+            }
+            
+            public Builder withReplayUnfinishedFiles(Boolean replayUnfinishedFiles) {
+                this.replayUnfinishedFiles = replayUnfinishedFiles;
+                return this;
+            }
+            
+            public Builder withId(String id) {
+                this.id = id;
+                return this;
+            }
+            
+            public Request build() {
+                return new Request(this);
+            }
+        }
+    }
+}

--- a/src/test/java/datawave/microservice/audit/AuditClientDisabledTest.java
+++ b/src/test/java/datawave/microservice/audit/AuditClientDisabledTest.java
@@ -1,6 +1,7 @@
 package datawave.microservice.audit;
 
 import datawave.microservice.audit.config.AuditServiceConfiguration;
+import datawave.microservice.audit.replay.ReplayClient;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,6 +28,7 @@ public class AuditClientDisabledTest {
     @Test
     public void verifyAutoConfig() {
         assertEquals("No AuditClient beans should have been found", 0, context.getBeanNamesForType(AuditClient.class).length);
+        assertEquals("No ReplayClient beans should have been found", 0, context.getBeanNamesForType(ReplayClient.class).length);
         assertEquals("No AuditServiceConfiguration beans should have been found", 0, context.getBeanNamesForType(AuditServiceConfiguration.class).length);
         assertEquals("No AuditServiceProvider beans should have been found", 0, context.getBeanNamesForType(AuditServiceProvider.class).length);
     }

--- a/src/test/java/datawave/microservice/audit/replay/ReplayClientTest.java
+++ b/src/test/java/datawave/microservice/audit/replay/ReplayClientTest.java
@@ -1,0 +1,542 @@
+package datawave.microservice.audit.replay;
+
+import datawave.microservice.audit.AuditServiceProvider;
+import datawave.microservice.audit.TestUtils;
+import datawave.microservice.audit.config.AuditServiceConfiguration;
+import datawave.microservice.authorization.user.ProxiedUserDetails;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.springframework.beans.DirectFieldAccessor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.content;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withServerError;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+/**
+ * Tests {@link ReplayClient} and {@link ReplayClient.Request} functionality and ensures that audit {@code audit.enabled=true})
+ * <p>
+ * Utilizes mocked audit server to verify that expected REST calls are made
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@ContextConfiguration(classes = ReplayClientTest.TestConfiguration.class)
+@ActiveProfiles({"ReplayClientTest", "audit-enabled"})
+public class ReplayClientTest {
+    
+    private static final String EXPECTED_REPLAY_URI = "http://localhost:11111/audit/v1/replay";
+    
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+    
+    @Autowired
+    private ReplayClient replayClient;
+    
+    @Autowired
+    private ApplicationContext context;
+    
+    private MockRestServiceServer mockServer;
+    private ProxiedUserDetails defaultUserDetails;
+    
+    @Before
+    public void setup() throws Exception {
+        defaultUserDetails = TestUtils.userDetails(Collections.singleton("AuthorizedUser"), Arrays.asList("A", "B", "C", "D", "E", "F", "G", "H", "I"));
+        setupMockAuditServer();
+    }
+    
+    @Test
+    public void verifyAutoConfig() {
+        assertEquals("One ReplayClient bean should have been found", 1, context.getBeanNamesForType(ReplayClient.class).length);
+        assertEquals("One AuditServiceConfiguration bean should have been found", 1, context.getBeanNamesForType(AuditServiceConfiguration.class).length);
+        assertEquals("One AuditServiceProvider bean should have been found", 1, context.getBeanNamesForType(AuditServiceProvider.class).length);
+    }
+    
+    @Test
+    public void testCreateURISuccess() {
+        
+        //@formatter:off
+        final ReplayClient.Request replayRequest = new ReplayClient.Request.Builder()
+                .withProxiedUserDetails(defaultUserDetails)
+                .withPathUri("hdfs://some-path/")
+                .withSendRate(100l)
+                .withReplayUnfinishedFiles(true)
+                .build();
+
+        mockServer.expect(requestTo(EXPECTED_REPLAY_URI + "/create"))
+                .andExpect(content().formData(replayRequest.paramMap))
+                .andRespond(withSuccess());
+
+        replayClient.create(replayRequest);
+        mockServer.verify();
+        //@formatter:on
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void testCreateMissingParam() {
+        
+        //@formatter:off
+        final ReplayClient.Request replayRequest = new ReplayClient.Request.Builder()
+                .withProxiedUserDetails(defaultUserDetails)
+                .withSendRate(100l)
+                .withReplayUnfinishedFiles(true)
+                .build();
+
+        mockServer.expect(requestTo(EXPECTED_REPLAY_URI + "/create"))
+                .andExpect(content().formData(replayRequest.paramMap))
+                .andRespond(withSuccess());
+
+        replayClient.create(replayRequest);
+        mockServer.verify();
+        //@formatter:on
+    }
+    
+    @Test
+    public void testCreateURIServerError() {
+        expectedException.expect(HttpServerErrorException.class);
+        expectedException.expect(new TestUtils.StatusMatcher(500));
+        
+        //@formatter:off
+        final ReplayClient.Request replayRequest = new ReplayClient.Request.Builder()
+                .withProxiedUserDetails(defaultUserDetails)
+                .withPathUri("hdfs://some-path/")
+                .withSendRate(100l)
+                .withReplayUnfinishedFiles(true)
+                .build();
+
+        mockServer.expect(requestTo(EXPECTED_REPLAY_URI + "/create"))
+                .andExpect(content().formData(replayRequest.paramMap))
+                .andRespond(withServerError());
+
+        replayClient.create(replayRequest);
+        mockServer.verify();
+
+        //@formatter:on
+    }
+    
+    @Test
+    public void testCreateAndStartURISuccess() {
+        
+        //@formatter:off
+        final ReplayClient.Request replayRequest = new ReplayClient.Request.Builder()
+                .withProxiedUserDetails(defaultUserDetails)
+                .withPathUri("hdfs://some-path/")
+                .withSendRate(100l)
+                .withReplayUnfinishedFiles(true)
+                .build();
+
+        mockServer.expect(requestTo(EXPECTED_REPLAY_URI + "/createAndStart"))
+                .andExpect(content().formData(replayRequest.paramMap))
+                .andRespond(withSuccess());
+
+        replayClient.createAndStart(replayRequest);
+        mockServer.verify();
+        //@formatter:on
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void testCreateAndStartMissingParam() {
+        
+        //@formatter:off
+        final ReplayClient.Request replayRequest = new ReplayClient.Request.Builder()
+                .withProxiedUserDetails(defaultUserDetails)
+                .withSendRate(100l)
+                .withReplayUnfinishedFiles(true)
+                .build();
+
+        mockServer.expect(requestTo(EXPECTED_REPLAY_URI + "/createAndStart"))
+                .andExpect(content().formData(replayRequest.paramMap))
+                .andRespond(withSuccess());
+
+        replayClient.createAndStart(replayRequest);
+        mockServer.verify();
+        //@formatter:on
+    }
+    
+    @Test
+    public void testStartURISuccess() {
+        String id = "some-id";
+        
+        //@formatter:off
+        final ReplayClient.Request replayRequest = new ReplayClient.Request.Builder()
+                .withProxiedUserDetails(defaultUserDetails)
+                .withId("some-id")
+                .build();
+
+        mockServer.expect(requestTo(EXPECTED_REPLAY_URI + "/" + id + "/start"))
+                .andRespond(withSuccess());
+
+        replayClient.start(replayRequest);
+        mockServer.verify();
+        //@formatter:on
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void testStartMissingParam() {
+        String id = "some-id";
+        
+        //@formatter:off
+        final ReplayClient.Request replayRequest = new ReplayClient.Request.Builder()
+                .withProxiedUserDetails(defaultUserDetails)
+                .build();
+
+        mockServer.expect(requestTo(EXPECTED_REPLAY_URI + "/" + id + "/start"))
+                .andRespond(withSuccess());
+
+        replayClient.start(replayRequest);
+        mockServer.verify();
+        //@formatter:on
+    }
+    
+    @Test
+    public void testStartAllURISuccess() {
+        
+        //@formatter:off
+        final ReplayClient.Request replayRequest = new ReplayClient.Request.Builder()
+                .withProxiedUserDetails(defaultUserDetails)
+                .build();
+
+        mockServer.expect(requestTo(EXPECTED_REPLAY_URI + "/startAll"))
+                .andRespond(withSuccess());
+
+        replayClient.startAll(replayRequest);
+        mockServer.verify();
+        //@formatter:on
+    }
+    
+    @Test
+    public void testStatusURISuccess() {
+        String id = "some-id";
+        
+        //@formatter:off
+        final ReplayClient.Request replayRequest = new ReplayClient.Request.Builder()
+                .withProxiedUserDetails(defaultUserDetails)
+                .withId("some-id")
+                .build();
+
+        mockServer.expect(requestTo(EXPECTED_REPLAY_URI + "/" + id + "/status"))
+                .andRespond(withSuccess());
+
+        replayClient.status(replayRequest);
+        mockServer.verify();
+        //@formatter:on
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void testStatusMissingParam() {
+        String id = "some-id";
+        
+        //@formatter:off
+        final ReplayClient.Request replayRequest = new ReplayClient.Request.Builder()
+                .withProxiedUserDetails(defaultUserDetails)
+                .build();
+
+        mockServer.expect(requestTo(EXPECTED_REPLAY_URI + "/" + id + "/status"))
+                .andRespond(withSuccess());
+
+        replayClient.status(replayRequest);
+        mockServer.verify();
+        //@formatter:on
+    }
+    
+    @Test
+    public void testStatusAllURISuccess() {
+        
+        //@formatter:off
+        final ReplayClient.Request replayRequest = new ReplayClient.Request.Builder()
+                .withProxiedUserDetails(defaultUserDetails)
+                .build();
+
+        mockServer.expect(requestTo(EXPECTED_REPLAY_URI + "/statusAll"))
+                .andRespond(withSuccess());
+
+        replayClient.statusAll(replayRequest);
+        mockServer.verify();
+        //@formatter:on
+    }
+    
+    @Test
+    public void testUpdateURISuccess() {
+        String id = "some-id";
+        
+        //@formatter:off
+        final ReplayClient.Request replayRequest = new ReplayClient.Request.Builder()
+                .withProxiedUserDetails(defaultUserDetails)
+                .withId("some-id")
+                .withSendRate(100l)
+                .build();
+
+        mockServer.expect(requestTo(EXPECTED_REPLAY_URI + "/" + id + "/update"))
+                .andExpect(content().formData(replayRequest.paramMap))
+                .andRespond(withSuccess());
+
+        replayClient.update(replayRequest);
+        mockServer.verify();
+        //@formatter:on
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void testUpdateMissingParam1() {
+        String id = "some-id";
+        
+        //@formatter:off
+        final ReplayClient.Request replayRequest = new ReplayClient.Request.Builder()
+                .withProxiedUserDetails(defaultUserDetails)
+                .withId(id)
+                .build();
+
+        mockServer.expect(requestTo(EXPECTED_REPLAY_URI + "/" + id + "/update"))
+                .andRespond(withSuccess());
+
+        replayClient.update(replayRequest);
+        mockServer.verify();
+        //@formatter:on
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void testUpdateMissingParam2() {
+        String id = "some-id";
+        
+        //@formatter:off
+        final ReplayClient.Request replayRequest = new ReplayClient.Request.Builder()
+                .withProxiedUserDetails(defaultUserDetails)
+                .withSendRate(100l)
+                .build();
+
+        mockServer.expect(requestTo(EXPECTED_REPLAY_URI + "/" + id + "/update"))
+                .andExpect(content().formData(replayRequest.paramMap))
+                .andRespond(withSuccess());
+
+        replayClient.update(replayRequest);
+        mockServer.verify();
+        //@formatter:on
+    }
+    
+    @Test
+    public void testUpdateAllURISuccess() {
+        
+        //@formatter:off
+        final ReplayClient.Request replayRequest = new ReplayClient.Request.Builder()
+                .withProxiedUserDetails(defaultUserDetails)
+                .withSendRate(100l)
+                .build();
+
+        mockServer.expect(requestTo(EXPECTED_REPLAY_URI + "/updateAll"))
+                .andExpect(content().formData(replayRequest.paramMap))
+                .andRespond(withSuccess());
+
+        replayClient.updateAll(replayRequest);
+        mockServer.verify();
+        //@formatter:on
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void testUpdateAllMissingParam() {
+        
+        //@formatter:off
+        final ReplayClient.Request replayRequest = new ReplayClient.Request.Builder()
+                .withProxiedUserDetails(defaultUserDetails)
+                .build();
+
+        mockServer.expect(requestTo(EXPECTED_REPLAY_URI + "/updateAll"))
+                .andExpect(content().formData(replayRequest.paramMap))
+                .andRespond(withSuccess());
+
+        replayClient.updateAll(replayRequest);
+        mockServer.verify();
+        //@formatter:on
+    }
+    
+    @Test
+    public void testStopURISuccess() {
+        String id = "some-id";
+        
+        //@formatter:off
+        final ReplayClient.Request replayRequest = new ReplayClient.Request.Builder()
+                .withProxiedUserDetails(defaultUserDetails)
+                .withId("some-id")
+                .build();
+
+        mockServer.expect(requestTo(EXPECTED_REPLAY_URI + "/" + id + "/stop"))
+                .andRespond(withSuccess());
+
+        replayClient.stop(replayRequest);
+        mockServer.verify();
+        //@formatter:on
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void testStopMissingParam() {
+        String id = "some-id";
+        
+        //@formatter:off
+        final ReplayClient.Request replayRequest = new ReplayClient.Request.Builder()
+                .withProxiedUserDetails(defaultUserDetails)
+                .build();
+
+        mockServer.expect(requestTo(EXPECTED_REPLAY_URI + "/" + id + "/stop"))
+                .andRespond(withSuccess());
+
+        replayClient.stop(replayRequest);
+        mockServer.verify();
+        //@formatter:on
+    }
+    
+    @Test
+    public void testStopAllURISuccess() {
+        
+        //@formatter:off
+        final ReplayClient.Request replayRequest = new ReplayClient.Request.Builder()
+                .withProxiedUserDetails(defaultUserDetails)
+                .build();
+
+        mockServer.expect(requestTo(EXPECTED_REPLAY_URI + "/stopAll"))
+                .andRespond(withSuccess());
+
+        replayClient.stopAll(replayRequest);
+        mockServer.verify();
+        //@formatter:on
+    }
+    
+    @Test
+    public void testResumeURISuccess() {
+        String id = "some-id";
+        
+        //@formatter:off
+        final ReplayClient.Request replayRequest = new ReplayClient.Request.Builder()
+                .withProxiedUserDetails(defaultUserDetails)
+                .withId("some-id")
+                .build();
+
+        mockServer.expect(requestTo(EXPECTED_REPLAY_URI + "/" + id + "/resume"))
+                .andRespond(withSuccess());
+
+        replayClient.resume(replayRequest);
+        mockServer.verify();
+        //@formatter:on
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void testResumeMissingParam() {
+        String id = "some-id";
+        
+        //@formatter:off
+        final ReplayClient.Request replayRequest = new ReplayClient.Request.Builder()
+                .withProxiedUserDetails(defaultUserDetails)
+                .build();
+
+        mockServer.expect(requestTo(EXPECTED_REPLAY_URI + "/" + id + "/resume"))
+                .andRespond(withSuccess());
+
+        replayClient.resume(replayRequest);
+        mockServer.verify();
+        //@formatter:on
+    }
+    
+    @Test
+    public void testResumeAllURISuccess() {
+        
+        //@formatter:off
+        final ReplayClient.Request replayRequest = new ReplayClient.Request.Builder()
+                .withProxiedUserDetails(defaultUserDetails)
+                .build();
+
+        mockServer.expect(requestTo(EXPECTED_REPLAY_URI + "/resumeAll"))
+                .andRespond(withSuccess());
+
+        replayClient.resumeAll(replayRequest);
+        mockServer.verify();
+        //@formatter:on
+    }
+    
+    @Test
+    public void testDeleteURISuccess() {
+        String id = "some-id";
+        
+        //@formatter:off
+        final ReplayClient.Request replayRequest = new ReplayClient.Request.Builder()
+                .withProxiedUserDetails(defaultUserDetails)
+                .withId("some-id")
+                .build();
+
+        mockServer.expect(requestTo(EXPECTED_REPLAY_URI + "/" + id + "/delete"))
+                .andRespond(withSuccess());
+
+        replayClient.delete(replayRequest);
+        mockServer.verify();
+        //@formatter:on
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void testDeleteMissingParam() {
+        String id = "some-id";
+        
+        //@formatter:off
+        final ReplayClient.Request replayRequest = new ReplayClient.Request.Builder()
+                .withProxiedUserDetails(defaultUserDetails)
+                .build();
+
+        mockServer.expect(requestTo(EXPECTED_REPLAY_URI + "/" + id + "/delete"))
+                .andRespond(withSuccess());
+
+        replayClient.delete(replayRequest);
+        mockServer.verify();
+        //@formatter:on
+    }
+    
+    @Test
+    public void testDeleteAllURISuccess() {
+        
+        //@formatter:off
+        final ReplayClient.Request replayRequest = new ReplayClient.Request.Builder()
+                .withProxiedUserDetails(defaultUserDetails)
+                .build();
+
+        mockServer.expect(requestTo(EXPECTED_REPLAY_URI + "/deleteAll"))
+                .andRespond(withSuccess());
+
+        replayClient.deleteAll(replayRequest);
+        mockServer.verify();
+        //@formatter:on
+    }
+    
+    /**
+     * Mocks the ReplayClient jwtRestTemplate field within the internal ReplayClient
+     */
+    private void setupMockAuditServer() {
+        RestTemplate replayRestTemplate = (RestTemplate) new DirectFieldAccessor(replayClient).getPropertyValue("jwtRestTemplate");
+        mockServer = MockRestServiceServer.createServer(replayRestTemplate);
+    }
+    
+    @Configuration
+    @Profile("ReplayClientTest")
+    @ComponentScan(basePackages = "datawave.microservice")
+    public static class TestConfiguration {}
+    
+    @SpringBootApplication(scanBasePackages = "datawave.microservice")
+    public static class TestApplication {
+        public static void main(String[] args) {
+            SpringApplication.run(ReplayClientTest.TestApplication.class, args);
+        }
+    }
+}


### PR DESCRIPTION
I'm sure I screwed up by updating the pom from snapshot to release.  I can fix that and we can do a separate release commit if need be.  I just wanted eyes on this since there are multiple PRs associated with this both here and in the audit service itself.

https://github.com/NationalSecurityAgency/datawave-audit-service/pull/2